### PR TITLE
RF: check for "mock' module when running tests

### DIFF
--- a/nibabel/__init__.py
+++ b/nibabel/__init__.py
@@ -67,16 +67,17 @@ from . import mriutils
 from . import streamlines
 from . import viewers
 
-# be friendly on systems with ancient numpy -- no tests, but at least
-# importable
+# Note test requirement for "mock".  Requirement for "nose" tested by numpy.
 try:
+    import mock
+except ImportError:
+    def test(*args, **kwargs):
+        raise RuntimeError('Need "mock" package for tests')
+else:
     from numpy.testing import Tester
     test = Tester().test
     bench = Tester().bench
-    del Tester
-except ImportError:
-    def test(*args, **kwargs):
-        raise RuntimeError('Need numpy >= 1.2 for tests')
+    del mock, Tester
 
 from .pkg_info import get_pkg_info as _get_pkg_info
 


### PR DESCRIPTION
Drop numpy check as we already require numpy >= 1.5.
